### PR TITLE
Fixed bug with radioactive yield tables reading

### DIFF
--- a/omega.py
+++ b/omega.py
@@ -3230,7 +3230,7 @@ class omega( chem_evol ):
         # This dictionary contains the mass fraction contribution toward the total
         # by SN1a's for each species
         species_frac_1a = {k: species_mass_1a[k] / species_mass_gal[k]
-        for k in species_mass_1a if k in species_mass_gal}        
+        for k in species_mass_1a if k in species_mass_gal}
 
         map_str_dic = {
         "agb":species_mass_agb,

--- a/read_yields.py
+++ b/read_yields.py
@@ -11,7 +11,7 @@ from __future__ import (division, print_function, absolute_import,
     Two classes: One for reading and extracting of
     NuGrid table data, the other one for SN1a data.
 
-    = = = = = = = = = = = = = = = = 
+    = = = = = = = = = = = = = = = =
 
     New version: Benoit Cote, May 2020
 
@@ -73,8 +73,8 @@ class read_yields( object ):
             M: Initial mass of the model
             Z: Initial metallicity of the model
             quantity: "Lifetime", "Mfinal", "Yields", "C-12", ...
-            isotopes: If empty, use self.isotopes for Yields and Xo
-                      If provide Yields and X0 will follow that list
+            isotopes: If empty, use self.isotopes for Yields and X0
+                      If provided Yields and X0 will follow that list
 
         '''
 
@@ -112,7 +112,7 @@ class read_yields( object ):
 
         '''
 
-        Return an array of isotopic yields, in sync with the 
+        Return an array of isotopic yields, in sync with the
         self.isotopes array
 
         Arguments
@@ -261,7 +261,7 @@ class read_yields( object ):
         Declare general parameters for reading yields tables
 
 
-        ''' 
+        '''
 
         # Define whether the list of isotopes is provided
         iso_provided = True
@@ -297,7 +297,7 @@ class read_yields( object ):
             model_label: name of the new model found in the yields table file
             iso_provided: True if the list of isotopes is pre-defined
        
-        ''' 
+        '''
 
         # Add the yields entry
         self.table[model_label] = dict()
@@ -325,7 +325,7 @@ class read_yields( object ):
             model_label: name of the new model found in the yields table file
             iso_provided: True if the list of isotopes is pre-defined
        
-        ''' 
+        '''
 
         # If the list of isotopes is pre-defined ..
         if iso_provided:
@@ -429,7 +429,7 @@ class read_yields( object ):
                 self.net_yields_available = False
 
             # Check if the initial composition add to 1.0
-            else: 
+            else:
                 X0_sum = sum(self.table[model]["X0"].values())
                 ratio_tol = np.minimum(X0_sum,1.0) / np.maximum(X0_sum,1.0)
                 if ratio_tol < self.X0_tol:
@@ -843,9 +843,9 @@ class iniabu():
 
 # Below
 # # # # # # # # # # # # # # # # # # # # # #
-#                                         # 
+#                                         #
 #           NOT    UPDATED    YET         #
-#                                         # 
+#                                         #
 # # # # # # # # # # # # # # # # # # # # # #
 
 

--- a/sygma.py
+++ b/sygma.py
@@ -2370,21 +2370,21 @@ class sygma( chem_evol ):
 
 
         '''
-	Plots yield contribution (Msun) of a certain mass range
-	versus initial mass. Each stellar ejecta in one mass range
-	is represented by the same yields, yields from certain stellar simulation.
-	Be aware that a larger mass range means also a larger amount
-	of yield for that range.
-	Note: Used in WENDI.
+        Plots yield contribution (Msun) of a certain mass range
+        versus initial mass. Each stellar ejecta in one mass range
+        is represented by the same yields, yields from certain stellar simulation.
+        Be aware that a larger mass range means also a larger amount
+        of yield for that range.
+        Note: Used in WENDI.
 
         Parameters
         ----------
         specie : string
             Element or isotope name in the form 'C' or 'C-12'
-	rebin : change the bin size to uniform mass intervals of size 'rebin'
-	        default 0, bin size is defined by ranges of (stellar) yield inputs	
-	log : boolean
-	    if true, use log yaxis
+        rebin : change the bin size to uniform mass intervals of size 'rebin'
+            default 0, bin size is defined by ranges of (stellar) yield inputs
+        log : boolean
+            if true, use log yaxis
         label : string
              figure label
         marker : string


### PR DESCRIPTION
Mainly a bug in which the stable isotope list was passed for
radioisotopes for some functions, including extrapolate_high_mass and
get_YZ_delayed_extra. Most of it was in get_y_low_upp.

Fixed whitespace and tab mixes and trailing whitespaces too.